### PR TITLE
Add flush and allow default aws options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ cwbMetrics.stat('serverload', 10, 'Percent', {
 // Send a log
 cwbLogs.log('errors', 'Test message');
 cwbLogs.log('signups', 'New user');
+
+// Force flush of all queued messages (with callback)
+cwbLogs.flush(function(err) {
+  if (err) { console.error('Something went wrong while writing log...', err); }
+});
 ```
 
 ## Options
@@ -76,6 +81,8 @@ cwbLogs.log('signups', 'New user');
 ### AWS Options
 
 The AWS options object must be a valid config object supported by AWS (see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html). You *must* provide a region.
+
+If no options are specified, the AWS SDK will use the default system credentials & options, if available.
 
 ### Metrics
 

--- a/index.js
+++ b/index.js
@@ -5,11 +5,12 @@ var logsHelper = require(__dirname + '/logs.js');
 
 var CloudWatchBuddy = function(aws){
     // Ensure a region is passed
-    if (!aws || !aws.region) {
+    if (aws && !aws.region) {
         throw new Error('Valid AWS config with a region is required');
     }
 
-    AWS.config.update(aws);
+    // Only configure if specified (otherwise, use system-provided options)
+    if (aws) { AWS.config.update(aws); }
 
     return {
         metrics: function(options) {

--- a/logs.js
+++ b/logs.js
@@ -36,7 +36,7 @@ var CloudWatchBuddyLogs = function(cloudwatchlogs, svc, s3, options){
         });
     }
 
-    var putLogData = function() {
+    var putLogData = function(callback) {
         clearInterval(_uploadInterval);
 
         if (_debug) { console.log (new Date() + ' : CloudWatchBuddyLogs : INFO : Put logs called'); }
@@ -106,6 +106,7 @@ var CloudWatchBuddyLogs = function(cloudwatchlogs, svc, s3, options){
             }
             if (_debug) { console.log (new Date() + ' : CloudWatchBuddyLogs : INFO : Finished putting logs. Resetting timer'); }
             setUploadInterval();    // Reset timer for next loop
+            if (callback) { callback(err); }
         });
     };
 
@@ -213,6 +214,11 @@ var CloudWatchBuddyLogs = function(cloudwatchlogs, svc, s3, options){
             if (_debug) { console.log (new Date() + ' : CloudWatchBuddyLogs : INFO : Size of log queue for stream ' + stream + ' ' + _queuedSize[stream] + ' bytes is greater than max size of ' + _maxSize + ' bytes'); }
             putLogData();
         }
+    };
+    
+    api.flush = function(callback) {
+      if (_debug) { console.log (new Date() + ' : CloudWatchBuddyLogs : INFO : Flush called, calling put logs'); }
+      putLogData(callback);
     };
 
     return api;

--- a/metrics.js
+++ b/metrics.js
@@ -43,7 +43,7 @@ var CloudWatchBuddyMetrics = function(cloudwatch, options){
     var _debug = (options.debug && typeof options.debug === 'boolean') ? options.debug : false;
     //var _maxSize = (typeof options.maxSize === 'number' && options.maxSize < 40000) ? options.maxSize : 40000;  // Max upload size if 40KB // TODO: add this option
 
-    var putMetricData = function() {
+    var putMetricData = function(callback) {
         clearInterval(_uploadInterval);
 
         if (_debug) { console.log (new Date() + ' : CloudWatchBuddyMetrics : INFO : Put metrics called'); }
@@ -146,10 +146,12 @@ var CloudWatchBuddyMetrics = function(cloudwatch, options){
                 if (!err && _debug) { console.log (new Date() + ' : CloudWatchBuddyMetrics : INFO : Put metrics success'); }
                 // TODO: if err, see if retryable
                 setUploadInterval();
+                if (callback) { callback(err); }
             });
         } else {
             if (_debug) { console.log (new Date() + ' : CloudWatchBuddyMetrics : INFO : No metrics to put'); }
             setUploadInterval();
+            if (callback) { callback(); }
         }
     }
 
@@ -243,6 +245,11 @@ var CloudWatchBuddyMetrics = function(cloudwatch, options){
             _stats[key].SampleCount++;
             _stats[key].Sum += value;
         }
+    };
+    
+    api.flush = function(callback) {
+      if (_debug) { console.log (new Date() + ' : CloudWatchBuddyMetrics : INFO : Flush called, calling put metrics'); }
+      putMetricData(callback);
     };
 
     return api;


### PR DESCRIPTION
I've adusted the aws options hash to allow nil to be passed (which will allow the AWS SDK to use the default system credentials) -- this was needed to use this module on AWS Lambda (where creds are provided by the IAM role innately)

In addition, to support a pure async operation, I added a flush method with a callback, which allows you to callback once all messages have been written.
